### PR TITLE
fix build warning for feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: nil
+layout: null
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
When starting the server with `jekyll serve --watch`, it shows the following warning:

```
Build Warning: Layout 'nil' requested in feed.xml does not exist.
```

It's no big deal, but this small fix removes the build warning. :)