### PR TITLE
fix markdown headers in some of the pages

### DIFF
--- a/for_speakers/excuses-excuses.md
+++ b/for_speakers/excuses-excuses.md
@@ -12,7 +12,7 @@ You can only win a speaker slot if you enter the competition. If you were previo
 
 Here is why you won’t, and why those reasons aren’t valid:
 
-##1. You think "I have nothing to talk about"
+## 1. You think "I have nothing to talk about"
 
 We all benefit from hearing different points of view. Your point of view and your way of expressing it is unique. You may think someone else has already expressed every idea or opinion you have, but no one but you possesses *your* particular combination of thoughts and ways of expressing them.
 
@@ -24,25 +24,25 @@ In this short talk, Chiu-Ki Chan ([@chiuki](https://twitter.com/chiuki)) shares 
 
 You can also talk about something brand new for you. It doesn’t matter if you don’t know anything about the topic yet, either, since I promise you will know a lot about it when you give the talk. Giving a talk is a fantastic way to learn. Give the talk you want to hear.
 
-##2. You think “I’d be a terrible speaker”
+## 2. You think “I’d be a terrible speaker”
 
 You need only two things to be a great speaker: practice and confidence. The fastest route to confidence is practice, so really you just need practice. Practice means: rehearsing your talk a few times before giving it, but also giving more talks to get better at preparing them.
 
 I started small: I gave a lightning talk which was just a book review at one of my local meet-ups. Then I gave an introductory how-to on making bookmarklets to the same group. The trick to getting started was that I chose a topic and an audience I felt really comfortable with, and progressed from there.
 
-##3. You think “I’m afraid of public speaking”
+## 3. You think “I’m afraid of public speaking”
 
 Why, because you are afraid of looking stupid in front of a crowd? PROTIP: Being afraid of looking stupid is actually a fantastic motivator for being well-prepared. Most of us are intimidated by public speaking. I’m afraid every single time, but then, because I’m prepared and I’ve practiced, everything goes well and I end up feeling great.
 
-##4. You think “I’m not nearly as nerdy and intense as some of those guys I’ve seen give talks”
+## 4. You think “I’m not nearly as nerdy and intense as some of those guys I’ve seen give talks”
 
 GOOD. Those guys don’t represent programmers in general, and you should not compare yourself with them. Be you. That’s the whole point of having diverse people participate; for diverse viewpoints.
 
-##5. You think “But I’m not ready yet!”
+## 5. You think “But I’m not ready yet!”
 
 All you need to prepare and submit is a talk *proposal*. Spend an evening sketching out an idea, and write up a paragraph describing the theme. If your proposal is accepted, then you can get to work on getting the talk prepared. If you are serious about getting involved as a speaker in general, then propose a short talk at your next local meet-up, and submit talk proposals at a few conferences.
 
-##Convinced?
+## Convinced?
 
 If you need help brainstorming ideas, writing a talk proposal, making your slides, finding speaking engagements, *or anything else* [please contact us](http://twitter.com/theophani).
 

--- a/for_speakers/practical-tips-for-becoming-a-great-speaker.md
+++ b/for_speakers/practical-tips-for-becoming-a-great-speaker.md
@@ -10,23 +10,23 @@ summary: Tips for both preparing your talk, and being a good presenter of the co
 
 These tips are for both preparing your talk, and being a good presenter of the content. These tips are just a start. I plan to gather more resources, examples of great talks, and will expand and change this post as I get feedback.
 
-##Have a clear reason for giving the talk
+## Have a clear reason for giving the talk
 
 Technical talks range from pure opinion to strictly instructional. Whatever the flavour, identify for yourself why *you* are motivated to give *this* talk, and use that motivation to guide you. As you prepare, occasionally assess whether your talk is still focused on its goal.
 
 Your talk should also motivate your audience about the topic. If the only thing they take away from your talk is a drive to explore more on the topic themselves, you have succeeded.
 
-##State your thesis
+## State your thesis
 
 A talk is not a mystery novel: be clear and state the point you want people to understand. State it at the beginning and also at the end. It might even be the title of your talk as well.
 
-##Know your ideas, not the exact words
+## Know your ideas, not the exact words
 
 You must practice your talk in order to be confident on stage. You also want to be able to talk to your audience, not read from notes.
 
 The way to avoid reading from your notes, and to sound casual, is to remember a series of core ideas you want to express, instead of exact words. When you are rehearsing (and timing) your talk, if you must refer to your notes, refer only to your list of ideas.
 
-##Structure: have it
+## Structure: have it
 
 In storytelling, there are different kinds of narratives, but the most engaging and satisfying* ones have:
 
@@ -40,19 +40,19 @@ If the middle of your talk has a series of distinct sections, let your audience 
 
 For a variation on this theme, check the TEDx talk ["the secret structure of great talks"](http://www.ted.com/talks/nancy_duarte_the_secret_structure_of_great_talks.html) by Nancy Duarte.
 
-##Introduce yourself
+## Introduce yourself
 
 The point of your personal introduction is not to give your life story (snore), but to give you credibility. If your talk is mostly opinion, then justify why your opinion is valuable. For example, “As a beginner, my experience illustrates the kinds of frustration other beginners have” or “In my 5 years experience, I've seen this pattern again and again.” Such statements add credibility and can thus engage your audience.
 
-##Pacing
+## Pacing
 
 Give time for people to think. I used to be afraid that I had to rush through everything I was saying, or else I might appear confused or lost. When you are giving a talk, you notice those silences, but your audience, meanwhile, is still digesting what you just said. Presenting is *not* radio. You won't look stupid or forgetful if you pause to refer your notes between ideas. Take a breath, or, if you need an excuse to pause, take a sip of water.
 
-##Is your talk beginner, intermediate or advanced?
+## Is your talk beginner, intermediate or advanced?
 
 If you are giving an instructional talk, then state what level of instruction you will give and what the listener can expect to know at the end. For example "In this introductory talk, you will get a taste for when this library is useful, and learn when you shouldn't use it" or "I'll give detailed instructions for two different ways to accomplish this result."
 
-##Tell your audience only what they *don’t* know
+## Tell your audience only what they *don’t* know
 
 Identify what you assume the audience knows and doesn't know. This is what people mean when they say "know your audience." In your talk, state your assumptions. Here is a template you can use: "You have done X before, and you know Y, but I think you did not know Z".
 
@@ -60,7 +60,7 @@ I lifted this template almost word for word from Lea Verou's [CSS3 Secrets: 10 t
 
 This technique gives context, shows you know the audience is knowledgeable, and makes it clear what your goals are. Win, win, win.
 
-##Stay on topic
+## Stay on topic
 
 If you spend too much time talking about a side topic, your audience may stop paying attention, or get confused.
 
@@ -68,7 +68,7 @@ If you find yourself with more than one slide about a side topic, then guess wha
 
 If understanding the side topic is a prerequisite *and* you assume your audience does not know it, then explain the absolute minimum required to understand *your* talk only.
 
-##Learn from others
+## Learn from others
 
 As you watch anyone give a talk, pay attention to what you liked, and didn't like. When working and re-working your own talk, go back to those thoughts: Can you use any of the effective techniques in your talk? Are you making any of the same mistakes?
 
@@ -76,7 +76,7 @@ Or learn from this person, Caroline Drucker ([@bougie](https://twitter.com/bougi
 
 <iframe width="509" height="286" src="http://www.youtube.com/embed/2H36kbMMrZo" frameborder="0" allowfullscreen="true"> </iframe>
 
-##More advice
+## More advice
 
 Other people have shared their advice from their personal experience too. Be inspired!
 

--- a/for_speakers/starting-with-nothing.md
+++ b/for_speakers/starting-with-nothing.md
@@ -8,7 +8,7 @@ summary: It is possible to give a great talk on a subject you didn’t know much
 
 # {{ page.title }}
 
-##Well, *almost* nothing
+## Well, *almost* nothing
 
 A lot of conferences have calls for proposals (CFPs) months before the conference, but the speakers often present super-fresh stuff. I had a hunch, so I asked the Twitters:
 
@@ -21,7 +21,7 @@ A lot of conferences have calls for proposals (CFPs) months before the conferenc
 <blockquote class="twitter-tweet"><p>Were you successful? Were you selected? How was the talk? Please tell me about it! I'm collecting experiences.</p>&mdash; Tiffany Conroy (@theophani) <a href="https://twitter.com/theophani/status/212509420012314627" data-datetime="2012-06-12T11:39:28+00:00">June 12, 2012</a></blockquote>
 
 
-##And?
+## And?
 
 What I found out did not surprise me, but it might surprise you:
 
@@ -35,7 +35,7 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> I gave a talk on indie rappers and similarities between their hustle and businesses building open source once. It went well.</p>&mdash; Corey Donohoe (@atmos) <a href="https://twitter.com/atmos/status/212584388494499840" data-datetime="2012-06-12T16:37:22+00:00">June 12, 2012</a></blockquote>
 
-###It's totally common in academia
+### It's totally common in academia
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> Yes. presenting on it in 3 weeks.</p>&mdash; moink (@moink_tdr) <a href="https://twitter.com/moink_tdr/status/212527646049972224" data-datetime="2012-06-12T12:51:54+00:00">June 12, 2012</a></blockquote>
 
@@ -45,7 +45,7 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> A presenter once said “The best model in the abstract is wrong. This is actually the best model.”</p>&mdash; Mark James Adams (@mja) <a href="https://twitter.com/mja/status/212533129037086721" data-datetime="2012-06-12T13:13:41+00:00">June 12, 2012</a></blockquote>
 
-###… and in our industry as well
+### … and in our industry as well
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> yes. It went really well as I was forced to understand the topic in detail to write the talk. And my approach to learning...</p>&mdash; Christian Heilmann(@codepo8) <a href="https://twitter.com/codepo8/status/212531361494482945" data-datetime="2012-06-12T13:06:39+00:00">June 12, 2012</a></blockquote>
 
@@ -59,13 +59,13 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212531080509657088"><p>@<a href="https://twitter.com/theophani">theophani</a> @<a href="https://twitter.com/janl">janl</a> not on a topic I didn't know about, but nearly always a incomplete or non-started idea.</p>&mdash; Remy Sharp (@rem) <a href="https://twitter.com/rem/status/212531261644873728" data-datetime="2012-06-12T13:06:16+00:00">June 12, 2012</a></blockquote>
 
-###And it's highly recommended
+### And it's highly recommended
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> yup, and this works awesomely for pushing yourself out of the comfort zone - did it several times</p>&mdash; Douglas Campos (@qmx) <a href="https://twitter.com/qmx/status/212533198670925824" data-datetime="2012-06-12T13:13:57+00:00">June 12, 2012</a></blockquote>
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> of course! Best impetus to learn it, finish it, flesh it out.</p>&mdash; Jessica Kerr (@jessitron) <a href="https://twitter.com/jessitron/status/212535457739849728" data-datetime="2012-06-12T13:22:56+00:00">June 12, 2012</a></blockquote>
 
-###… though not by everyone
+### … though not by everyone
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509420012314627"><p>@<a href="https://twitter.com/theophani">theophani</a> I gave a talk about Extreme Programming in '99 in a big conference after reading just the books. Was well received. Never again.</p>&mdash; Lalo Martins (@lalomartins) <a href="https://twitter.com/lalomartins/status/212521367139131394" data-datetime="2012-06-12T12:26:57+00:00">June 12, 2012</a></blockquote>
 
@@ -75,7 +75,7 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212522948408524800"><p>@<a href="https://twitter.com/theophani">theophani</a> I thought about, but I have not enough time to read into the topic and made a presentation. Time is missing all the time :-(</p>&mdash; Fabian Blechschmidt (@Fabian_ikono) <a href="https://twitter.com/Fabian_ikono/status/212597210041434113" data-datetime="2012-06-12T17:28:19+00:00">June 12, 2012</a></blockquote>
 
-###It's a great way to motivate yourself
+### It's a great way to motivate yourself
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> Submitting talk proposals for incomplete projects is my primary method of setting deadlines ;)</p>&mdash; Jan Schmidt (@thaytan) <a href="https://twitter.com/thaytan/status/212533090797629440" data-datetime="2012-06-12T13:13:32+00:00">June 12, 2012</a></blockquote>
 
@@ -85,14 +85,14 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509420012314627"><p>@<a href="https://twitter.com/theophani">theophani</a> It's a tremendous motivating force.</p>&mdash; James Coglan (@jcoglan) <a href="https://twitter.com/jcoglan/status/212532856818372610" data-datetime="2012-06-12T13:12:36+00:00">June 12, 2012</a></blockquote>
 
-###It's a great way to learn
+### It's a great way to learn
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509267520012288"><p>@<a href="https://twitter.com/theophani">theophani</a> @<a href="https://twitter.com/rmurphey">rmurphey</a> absolutely. Nothing gets you learning like the looming threat of a deadline.</p>&mdash; Andy Matthews (@commadelimited) <a href="https://twitter.com/commadelimited/status/212538538816831489" data-datetime="2012-06-12T13:35:11+00:00">June 12, 2012</a></blockquote>
 
 
 <blockquote class="twitter-tweet"><p>@<a href="https://twitter.com/theophani">theophani</a> @<a href="https://twitter.com/rmurphey">rmurphey</a> Constantly. For me, it's an opportunity to explore ideas and start a discussion. Always had success with it.</p>&mdash; Jen Myers (@antiheroine) <a href="https://twitter.com/antiheroine/status/212532644523679744" data-datetime="2012-06-12T13:11:45+00:00">June 12, 2012</a></blockquote>
 
-###But warning: It can be a lot of work
+### But warning: It can be a lot of work
 
 <blockquote class="twitter-tweet" data-in-reply-to="212509420012314627"><p>@<a href="https://twitter.com/theophani">theophani</a> I totally did it here: <a href="http://t.co/1bR2ztZa" title="http://conferenciarails.org/speakers.html#porras">conferenciarails.org/speakers.html#…</a> I learnt a lot, had lots of fun and I think the audience enjoyed too. Very positive!</p>&mdash; Sergio (@porras) <a href="https://twitter.com/porras/status/212529469041287169" data-datetime="2012-06-12T12:59:08+00:00">June 12, 2012</a></blockquote>
 
@@ -104,7 +104,7 @@ What I found out did not surprise me, but it might surprise you:
 
 <blockquote class="twitter-tweet" data-in-reply-to="212530248380710913"><p>@<a href="https://twitter.com/theophani">theophani</a> … is making sure I have enough time to prepare it right and actually have some sleep in the previous week</p>&mdash; Sergio (@porras) <a href="https://twitter.com/porras/status/212535751072681984" data-datetime="2012-06-12T13:24:06+00:00">June 12, 2012</a></blockquote>
 
-##Learning from rejection
+## Learning from rejection
 
 These are the success (mostly) stories of people whose talk proposals got accepted. But what if your proposal is rejected? That might suck, right? But even
 


### PR DESCRIPTION
The headers in a couple of pages were missing a space between the text and the `#`, so they looked un-styled. This should fix it!